### PR TITLE
Add inbox chat example

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,14 @@ WebSocket service:
 
 Together these functions allow services and web clients to communicate in real
 time while enforcing permissions and handling many connections.
+
+## Example Inbox Chat
+
+An example chat server using the library is provided in `examples/inbox-chat`. It creates a `subscriber` for each connection and subscribes that client to the inbox ID extracted from the WebSocket URL.
+Start the server:
+
+```bash
+php examples/inbox-chat/server.php
+```
+
+Open `examples/inbox-chat/index.html` in a browser to connect. Clients specify an inbox ID in the WebSocket URL. Messages are only echoed to other clients connected with the same inbox ID.

--- a/examples/inbox-chat/index.html
+++ b/examples/inbox-chat/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Inbox Chat Demo</title>
+</head>
+<body>
+<label>Inbox ID: <input id="inbox" value="room1"></label>
+<button id="connect">Connect</button>
+<div id="status"></div>
+<textarea id="out" cols="80" rows="10" readonly></textarea><br>
+<input id="msg" size="60"><button id="send">Send</button>
+<script>
+let ws;
+const out = document.getElementById('out');
+document.getElementById('connect').onclick = () => {
+  const inbox = document.getElementById('inbox').value;
+  ws = new WebSocket(`ws://localhost:8080/?inbox=${encodeURIComponent(inbox)}`);
+  ws.onopen = () => document.getElementById('status').innerText = 'connected';
+  ws.onmessage = e => { out.value += e.data + '\n'; };
+  ws.onclose = () => document.getElementById('status').innerText = 'closed';
+};
+document.getElementById('send').onclick = () => {
+  if(ws && ws.readyState === WebSocket.OPEN) ws.send(document.getElementById('msg').value);
+};
+</script>
+</body>
+</html>

--- a/examples/inbox-chat/server.php
+++ b/examples/inbox-chat/server.php
@@ -1,0 +1,67 @@
+#!/usr/bin/env php
+<?php
+require_once __DIR__ . '/../../resources/classes/websocket_server.php';
+require_once __DIR__ . '/../../resources/classes/subscriber.php';
+
+class InboxChatServer extends websocket_server {
+    private $pending_inbox = [];
+    private $subscribers = [];
+
+    protected function handshake($socket) {
+        stream_set_blocking($socket, true);
+        $header = '';
+        while (($line = fgets($socket)) !== false) {
+            $header .= $line;
+            if (rtrim($line) === '') break;
+        }
+        $inbox = 'default';
+        if (preg_match('/GET\s+([^\s]+)\s+HTTP\//', $header, $m)) {
+            $uri = $m[1];
+            $parts = parse_url($uri);
+            parse_str($parts['query'] ?? '', $query);
+            $tmp = $query['inbox'] ?? trim($parts['path'], '/');
+            if ($tmp !== '') $inbox = $tmp;
+        }
+        if (!preg_match('/Sec-WebSocket-Key: (.*)\r\n/', $header, $m)) {
+            throw new RuntimeException('Invalid WebSocket handshake');
+        }
+        $key = trim($m[1]);
+        $accept = base64_encode(sha1($key . '258EAFA5-E914-47DA-95CA-C5AB0DC85B11', true));
+        $response = "HTTP/1.1 101 Switching Protocols\r\n".
+                   "Upgrade: websocket\r\n".
+                   "Connection: Upgrade\r\n".
+                   "Sec-WebSocket-Accept: {$accept}\r\n\r\n";
+        fwrite($socket, $response);
+        $this->pending_inbox[(int)$socket] = $inbox;
+    }
+
+    public function run_chat(string $address = '127.0.0.1', int $port = 8080) {
+        $this->address = $address;
+        $this->port = $port;
+        $self = $this;
+        $this->on_connect(function($socket) use ($self) {
+            $inbox = $self->pending_inbox[(int)$socket] ?? 'default';
+            $sub = new subscriber($socket, [InboxChatServer::class, 'send']);
+            $sub->subscribe($inbox);
+            $self->subscribers[(int)$socket] = $sub;
+        });
+        $this->on_message(function($socket, $msg) use ($self) {
+            $sender = $self->subscribers[(int)$socket] ?? null;
+            if ($sender === null) return;
+            $inbox = $sender->subscribed_to()[0] ?? 'default';
+            foreach ($self->subscribers as $id => $sub) {
+                if ($id !== (int)$socket && $sub->has_subscribed_to($inbox)) {
+                    $sub->send($msg);
+                }
+            }
+        });
+        $this->on_disconnect(function($socket) use ($self) {
+            unset($self->pending_inbox[(int)$socket]);
+            unset($self->subscribers[(int)$socket]);
+        });
+        return parent::run();
+    }
+}
+
+$server = new InboxChatServer('127.0.0.1', 8080);
+$server->run_chat();


### PR DESCRIPTION
## Summary
- add a simple chat demo using the websocket_server class
- document the example in the README
- use the library's subscriber class to store inbox subscriptions

## Testing
- `php -l examples/inbox-chat/server.php`


------
https://chatgpt.com/codex/tasks/task_b_687d78afbd3c832ab4edf6178dc54309