### PR TITLE
Add Ratchet-like chat server with built-in subscriptions

### DIFF
--- a/chat-server/Chat.php
+++ b/chat-server/Chat.php
@@ -1,0 +1,40 @@
+<?php
+
+require_once __DIR__ . '/MessageComponentInterface.php';
+require_once __DIR__ . '/Connection.php';
+
+class Chat implements MessageComponentInterface {
+    /** @var \SplObjectStorage */
+    private $clients;
+
+    public function __construct() {
+        $this->clients = new \SplObjectStorage();
+    }
+
+    public function onOpen(Connection $conn): void {
+        $this->clients->attach($conn);
+    }
+
+    public function onMessage(Connection $from, string $msg): void {
+        $topics = $from->getSubscriptions();
+        foreach ($this->clients as $client) {
+            if ($client === $from) {
+                continue;
+            }
+            foreach ($topics as $topic) {
+                if ($client->hasSubscription($topic)) {
+                    $client->send($msg);
+                    break;
+                }
+            }
+        }
+    }
+
+    public function onClose(Connection $conn): void {
+        $this->clients->detach($conn);
+    }
+
+    public function onError(Connection $conn, \Exception $e): void {
+        $conn->close();
+    }
+}

--- a/chat-server/Connection.php
+++ b/chat-server/Connection.php
@@ -1,0 +1,62 @@
+<?php
+
+class Connection {
+    private $socket;
+    private array $subscriptions = [];
+
+    public function __construct($socket) {
+        $this->socket = $socket;
+    }
+
+    public function send(string $msg): void {
+        $chunkSize = 4096;
+        $payloadLen = strlen($msg);
+        $offset = 0;
+        $first = true;
+        while ($offset < $payloadLen) {
+            $remaining = $payloadLen - $offset;
+            $chunk = substr($msg, $offset, min($chunkSize, $remaining));
+            $chunkLen = strlen($chunk);
+            $fin = ($offset + $chunkSize >= $payloadLen) ? 0x80 : 0x00;
+            $opcode = $first ? 0x1 : 0x0;
+            $first = false;
+            $header = chr($fin | $opcode);
+            if ($chunkLen <= 125) {
+                $header .= chr($chunkLen);
+            } elseif ($chunkLen <= 65535) {
+                $header .= chr(126) . pack('n', $chunkLen);
+            } else {
+                $lenBytes = '';
+                for ($i = 7; $i >= 0; $i--) {
+                    $lenBytes .= chr(($chunkLen >> ($i * 8)) & 0xFF);
+                }
+                $header .= chr(127) . $lenBytes;
+            }
+            @fwrite($this->socket, $header . $chunk);
+            $offset += $chunkLen;
+        }
+    }
+
+    public function close(): void {
+        if (is_resource($this->socket)) {
+            @fwrite($this->socket, "\x88\x00");
+            @fclose($this->socket);
+        }
+    }
+
+    public function subscribe(string $topic): void {
+        $this->subscriptions[$topic] = true;
+    }
+
+    public function hasSubscription(string $topic): bool {
+        return isset($this->subscriptions[$topic]);
+    }
+
+    public function getSubscriptions(): array {
+        return array_keys($this->subscriptions);
+    }
+
+    public function resource() {
+        return $this->socket;
+    }
+}

--- a/chat-server/IoServer.php
+++ b/chat-server/IoServer.php
@@ -1,0 +1,170 @@
+<?php
+
+require_once __DIR__ . '/MessageComponentInterface.php';
+require_once __DIR__ . '/Connection.php';
+
+class IoServer {
+    private MessageComponentInterface $app;
+    private string $address;
+    private int $port;
+    private $serverSocket;
+    private array $clients = [];
+    private bool $running = false;
+
+    public function __construct(MessageComponentInterface $app, string $address = '127.0.0.1', int $port = 8080) {
+        $this->app = $app;
+        $this->address = $address;
+        $this->port = $port;
+    }
+
+    public static function factory(MessageComponentInterface $app, string $address = '127.0.0.1', int $port = 8080): self {
+        return new self($app, $address, $port);
+    }
+
+    public function run(): int {
+        $this->serverSocket = stream_socket_server("tcp://{$this->address}:{$this->port}", $errno, $errstr);
+        if (!$this->serverSocket) {
+            throw new RuntimeException("Cannot bind socket ({$errno}): {$errstr}");
+        }
+        stream_set_blocking($this->serverSocket, false);
+        $this->running = true;
+
+        while ($this->running) {
+            $read = [$this->serverSocket];
+            foreach ($this->clients as $conn) {
+                $read[] = $conn->resource();
+            }
+            $write = $except = [];
+            if (false === stream_select($read, $write, $except, null)) {
+                break;
+            }
+            if (in_array($this->serverSocket, $read, true)) {
+                $socket = @stream_socket_accept($this->serverSocket, 0);
+                if ($socket) {
+                    $topic = $this->handshake($socket);
+                    stream_set_blocking($socket, false);
+                    $conn = new Connection($socket);
+                    $conn->subscribe($topic);
+                    $this->clients[(int)$socket] = $conn;
+                    try {
+                        $this->app->onOpen($conn);
+                    } catch (\Exception $e) {
+                        $this->app->onError($conn, $e);
+                    }
+                }
+                $key = array_search($this->serverSocket, $read, true);
+                if ($key !== false) unset($read[$key]);
+            }
+            foreach ($read as $socket) {
+                $conn = $this->clients[(int)$socket] ?? null;
+                if ($conn === null) continue;
+                $msg = $this->receiveFrame($socket);
+                if ($msg === '' && feof($socket)) {
+                    $this->removeClient($socket, $conn);
+                    continue;
+                }
+                try {
+                    $this->app->onMessage($conn, $msg);
+                } catch (\Exception $e) {
+                    $this->app->onError($conn, $e);
+                }
+            }
+        }
+
+        foreach ($this->clients as $conn) {
+            $conn->close();
+        }
+        if (is_resource($this->serverSocket)) {
+            fclose($this->serverSocket);
+        }
+        return 0;
+    }
+
+    private function removeClient($socket, Connection $conn): void {
+        unset($this->clients[(int)$socket]);
+        try {
+            $this->app->onClose($conn);
+        } catch (\Exception $e) {
+            $this->app->onError($conn, $e);
+        }
+        $conn->close();
+    }
+
+    private function handshake($socket): string {
+        stream_set_blocking($socket, true);
+        $header = '';
+        while (($line = fgets($socket)) !== false) {
+            $header .= $line;
+            if (rtrim($line) === '') break;
+        }
+        $topic = 'default';
+        if (preg_match('/GET\s+([^\s]+)\s+HTTP\//', $header, $m)) {
+            $uri = $m[1];
+            $parts = parse_url($uri);
+            parse_str($parts['query'] ?? '', $query);
+            $tmp = $query['inbox'] ?? trim($parts['path'], '/');
+            if ($tmp !== '') $topic = $tmp;
+        }
+        if (!preg_match('/Sec-WebSocket-Key: (.*)\r\n/', $header, $m)) {
+            throw new RuntimeException('Invalid WebSocket handshake');
+        }
+        $key = trim($m[1]);
+        $accept = base64_encode(sha1($key . '258EAFA5-E914-47DA-95CA-C5AB0DC85B11', true));
+        $response = "HTTP/1.1 101 Switching Protocols\r\n" .
+                   "Upgrade: websocket\r\n" .
+                   "Connection: Upgrade\r\n" .
+                   "Sec-WebSocket-Accept: {$accept}\r\n\r\n";
+        fwrite($socket, $response);
+        stream_set_blocking($socket, false);
+        return $topic;
+    }
+
+    private function readBytes($socket, int $length): string {
+        $data = '';
+        while (strlen($data) < $length && is_resource($socket)) {
+            $chunk = fread($socket, $length - strlen($data));
+            if ($chunk === false || $chunk === '') {
+                break;
+            }
+            $data .= $chunk;
+        }
+        return $data;
+    }
+
+    private function receiveFrame($socket): string {
+        $header = $this->readBytes($socket, 2);
+        if ($header === '') return '';
+        $byte1 = ord($header[0]);
+        $byte2 = ord($header[1]);
+        $final = ($byte1 >> 7) & 1;
+        $opcode = $byte1 & 0x0F;
+        $masked = ($byte2 >> 7) & 1;
+        $length = $byte2 & 0x7F;
+        if ($length === 126) {
+            $extended = $this->readBytes($socket, 2);
+            $length = unpack('n', $extended)[1];
+        } elseif ($length === 127) {
+            $extended = $this->readBytes($socket, 8);
+            $length = 0;
+            for ($i = 0; $i < 8; $i++) {
+                $length = ($length << 8) | ord($extended[$i]);
+            }
+        }
+        $mask = '';
+        if ($masked) {
+            $mask = $this->readBytes($socket, 4);
+        }
+        $payload = $this->readBytes($socket, $length);
+        if ($masked) {
+            $decoded = '';
+            for ($i = 0; $i < $length; $i++) {
+                $decoded .= $payload[$i] ^ $mask[$i % 4];
+            }
+            $payload = $decoded;
+        }
+        if ($opcode === 0x8) {
+            return '';
+        }
+        return $payload;
+    }
+}

--- a/chat-server/MessageComponentInterface.php
+++ b/chat-server/MessageComponentInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+interface MessageComponentInterface {
+    public function onOpen(Connection $conn): void;
+    public function onMessage(Connection $from, string $msg): void;
+    public function onClose(Connection $conn): void;
+    public function onError(Connection $conn, \Exception $e): void;
+}
+

--- a/chat-server/README.md
+++ b/chat-server/README.md
@@ -1,0 +1,33 @@
+# OOP Chat Server
+
+This folder contains a minimal chat server built from scratch using
+Ratchet-like callbacks. The implementation reuses the handshake logic
+from the original `examples/inbox-chat` example but is completely
+self contained.
+
+Each connection subscribes to a topic ("inbox") extracted from the URL.
+Messages are only broadcast to other clients subscribed to the same
+topic.
+
+## Files
+
+- `MessageComponentInterface.php` – interface defining the four
+  callback methods `onOpen`, `onMessage`, `onClose`, and `onError`.
+- `Connection.php` – represents a single client connection and stores
+  its topic subscriptions.
+- `IoServer.php` – lightweight WebSocket server that performs the
+  handshake, reads frames and invokes the callbacks on a provided
+  application.
+- `Chat.php` – simple chat application that forwards messages to all
+  peers with matching subscriptions.
+- `server.php` – entry point to run the server on `127.0.0.1:8080`.
+
+Run the chat server with:
+
+```bash
+php server.php
+```
+
+Connecting to `ws://127.0.0.1:8080/?inbox=myroom` will subscribe the
+client to `myroom`. Only clients in the same room receive each other's
+messages.

--- a/chat-server/server.php
+++ b/chat-server/server.php
@@ -1,0 +1,9 @@
+<?php
+
+require_once __DIR__ . '/Chat.php';
+require_once __DIR__ . '/IoServer.php';
+
+$chat = new Chat();
+$server = IoServer::factory($chat, '127.0.0.1', 8080);
+$server->run();
+


### PR DESCRIPTION
## Summary
- rewrite chat-server so that IoServer implements the WebSocket logic directly
- Connection tracks topic subscriptions and handles frame encoding
- Chat component now forwards messages only to subscribers of the same topic
- update README with new design details

## Testing
- `php -l chat-server/MessageComponentInterface.php`
- `php -l chat-server/Connection.php`
- `php -l chat-server/IoServer.php`
- `php -l chat-server/Chat.php`
- `php -l chat-server/server.php`


------
https://chatgpt.com/codex/tasks/task_b_687d83497880832a9bd4c9534c2fb9c4